### PR TITLE
Create nubis-ocr.yml

### DIFF
--- a/catalog/nubis-ocr/nubis-ocr.yml
+++ b/catalog/nubis-ocr/nubis-ocr.yml
@@ -1,0 +1,36 @@
+schema: https://htr-united.github.io/schema/2023-06-27/schema.json
+title: NuBIS-OCR
+url: https://github.com/ksefil/NuBIS-OCR
+authors:
+  - name: Kutay
+    surname: Sefil
+    roles:
+      - transcriber
+institutions: []
+description: >-
+  Ground truth dataset for a selection of printed books from NuBIS, the digital
+  library of the Bibliothèque Interuniversitaire de la Sorbonne.
+language:
+  - fra
+  - lat
+production-software: eScriptorium + Kraken
+automatically-aligned: true
+script:
+  - iso: Latn
+script-type: only-typed
+time:
+  notBefore: '1602'
+  notAfter: '1989'
+hands:
+  count: unknown
+  precision: exact
+license:
+  name: CC-BY 4.0
+  url: https://creativecommons.org/licenses/by/4.0/
+format: Alto-XML
+sources:
+  - reference: ''
+    link: https://nubis.bis-sorbonne.fr/
+volume:
+  - metric: pages
+    count: 57

--- a/catalog/nubis-ocr/nubis-ocr.yml
+++ b/catalog/nubis-ocr/nubis-ocr.yml
@@ -14,7 +14,7 @@ language:
   - fra
   - lat
 production-software: eScriptorium + Kraken
-automatically-aligned: true
+automatically-aligned: false
 script:
   - iso: Latn
 script-type: only-typed


### PR DESCRIPTION
Hello HTR-United!

This is a ground truth dataset for a selection of printed books from [NuBIS](https://nubis.bis-sorbonne.fr/), the digital library of the Bibliothèque Interuniversitaire de la Sorbonne.
The selected corpus consists of a sample of 3 pages taken from 19 printed books, making a total of 57 pages. These books, in French and Latin, cover a period from 1602 to 1989, with roughly one book every 20 years. 

